### PR TITLE
Fix for #4 - Windows Path Handling 

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -49,8 +49,10 @@ function getPackageJSON(M) {
     });
 }
 function readSources(M) {
-    var srcPattern = path.join(srcDir, '**/*.ts');
-    return M.fromTask(M.getFilenames(srcPattern)).chain(function (paths) {
+    var srcPattern = path.join(srcDir, '**', '*.ts');
+    return M.fromTask(M.getFilenames(srcPattern))
+        .map(function (paths) { return Array_1.array.map(paths, path.normalize); })
+        .chain(function (paths) {
         return M.log(paths.length + " modules found").chain(function () { return readFiles(M, paths); });
     });
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -88,10 +88,12 @@ function getPackageJSON(M: MonadFileSystem & MonadLog): App<PackageJSON> {
 }
 
 function readSources(M: MonadApp): App<Array<File>> {
-  const srcPattern = path.join(srcDir, '**/*.ts')
-  return M.fromTask<string, Array<string>>(M.getFilenames(srcPattern)).chain(paths =>
-    M.log(`${paths.length} modules found`).chain(() => readFiles(M, paths))
-  )
+  const srcPattern = path.join(srcDir, '**', '*.ts')
+  return M.fromTask<string, Array<string>>(M.getFilenames(srcPattern))
+    .map(paths => array.map(paths, path.normalize))
+    .chain(paths =>
+      M.log(`${paths.length} modules found`).chain(() => readFiles(M, paths))
+    )
 }
 
 function parseModules(M: MonadLog, files: Array<File>): App<Array<parser.Module>> {

--- a/src/core.ts
+++ b/src/core.ts
@@ -91,9 +91,7 @@ function readSources(M: MonadApp): App<Array<File>> {
   const srcPattern = path.join(srcDir, '**', '*.ts')
   return M.fromTask<string, Array<string>>(M.getFilenames(srcPattern))
     .map(paths => array.map(paths, path.normalize))
-    .chain(paths =>
-      M.log(`${paths.length} modules found`).chain(() => readFiles(M, paths))
-    )
+    .chain(paths => M.log(`${paths.length} modules found`).chain(() => readFiles(M, paths)))
 }
 
 function parseModules(M: MonadLog, files: Array<File>): App<Array<parser.Module>> {


### PR DESCRIPTION
Uses path.normalize to convert / produced by glob to \ on windows.