### PR TITLE
feat(core): Support any path in src in the examples

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -188,9 +188,16 @@ function addAssertImport(code: string): string {
 
 function handleImports(files: Array<File>, projectName: string): Array<File> {
   function replaceProjectName(source: string): string {
+    // import { foo } from 'projectName'
+    // import { foo } from 'projectName/lib/'
+    // import { foo } from 'projectName/bar'
     const root = new RegExp(`from '${projectName}'`, 'g')
     const module = new RegExp(`from '${projectName}/lib/`, 'g')
-    return source.replace(root, `from '../../src'`).replace(module, `from '../../src/`)
+    const other = new RegExp(`from '${projectName}/`, 'g')
+    return source
+      .replace(root, `from '../../src'`)
+      .replace(module, `from '../../src/`)
+      .replace(other, `from '../../src/`)
   }
   return files.map(f => {
     const handleProjectImports = replaceProjectName(f.content)

--- a/src/core.ts
+++ b/src/core.ts
@@ -188,11 +188,14 @@ function addAssertImport(code: string): string {
 
 function handleImports(files: Array<File>, projectName: string): Array<File> {
   function replaceProjectName(source: string): string {
+    // Matches imports of the form:
     // import { foo } from 'projectName'
-    // import { foo } from 'projectName/lib/'
-    // import { foo } from 'projectName/bar'
     const root = new RegExp(`from '${projectName}'`, 'g')
+    // Matches imports of the form:
+    // import { foo } from 'projectName/lib/...'
     const module = new RegExp(`from '${projectName}/lib/`, 'g')
+    // Matches imports of the form:
+    // import { foo } from 'projectName/...'
     const other = new RegExp(`from '${projectName}/`, 'g')
     return source
       .replace(root, `from '../../src'`)


### PR DESCRIPTION
This PR adds support for the following form of imports:

- `import { foo } from 'project-name/...'`

Currently the only supported import types in the `@example` blocks are:

- `import { foo } from 'project-name'`
- `import { foo } from 'project-name/lib/...'`

**Tests**

There are no tests for `src/core` so I did some manual tests by running in this repo and in fp-ts as well.

CLI output in the Asciicast:

[![asciicast](https://asciinema.org/a/307830.svg)](https://asciinema.org/a/307830)

Here is also a Asciicast of a project I have that fails with master but works with the PR:

[![asciicast](https://asciinema.org/a/307831.svg)](https://asciinema.org/a/307831)

---

**NOTE**: I know this is a tool for your own projects and it aims to be opinionated. I will understand if you don't think the PR should be merged. I decided to create the PR since is a small change in code, instead of asking in an issue.