### PR TITLE
Use ts-node.cmd on windows

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -221,7 +221,8 @@ const spawnTsNode: Effect<void> = C =>
     C.log(`Type checking examples...`),
     TE.chain(() =>
       TE.fromIOEither(() => {
-        const { status } = spawnSync('ts-node', [path.join(outDir, 'examples', 'index.ts')], { stdio: 'inherit' })
+        const executableName = process.platform === 'win32' ? 'ts-node.cmd' : 'ts-node'
+        const { status } = spawnSync(executableName, [path.join(outDir, 'examples', 'index.ts')], { stdio: 'inherit' })
         return status === 0 ? E.right(undefined) : E.left('Type checking error')
       })
     )


### PR DESCRIPTION
Windows being Windows, is unable to spawn ts-node and gives back ENOENT error. 
Using ts-node.cmd solves the issue, so this PR adds a check on the executing environment and conditionally uses ts-node.cmd instead of ts-node.