### PR TITLE
feat(cli): print error as non coerced string

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -9,9 +9,10 @@
 import { main } from '.'
 import chalk from 'chalk'
 
-// tslint:disable-next-line: no-console
 main().catch((e) => {
+  // tslint:disable-next-line: no-console
   console.log(chalk.bold.red('Unexpected Error'))
+  // tslint:disable-next-line: no-console
   console.error(e)
   process.exit(1)
 })

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -6,9 +6,12 @@
  * @since 0.2.0
  */
 
+import { main } from '.'
 import chalk from 'chalk'
 
-import { main } from '.'
-
 // tslint:disable-next-line: no-console
-main().catch((e) => console.log(chalk.bold.red(`Unexpected error: ${e}`)))
+main().catch((e) => {
+  console.log(chalk.bold.red('Unexpected Error'))
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
When coercing an error to a string, it converts to `error.message`.

The call stack is not displayed in this message, and it's the most critical part in debugging.

This is the quick fix. The next best thing is to have a `--debug` flag that switches between original implementation and this suggested implementation.

#27 