### PR TITLE
Allow double quotes in `@example` project imports

### DIFF
--- a/src/Core.ts
+++ b/src/Core.ts
@@ -236,7 +236,7 @@ const replaceProjectName = (source: string): Program<string> =>
   pipe(
     RTE.ask<Environment>(),
     RTE.map(({ settings }) => {
-      const mkImportRegex = (projectName: string) => new RegExp(`from '${projectName}'`, 'g')
+      const mkImportRegex = (projectName: string) => new RegExp(`from ('${projectName}')|("${projectName}")`, 'g')
 
       // Matches imports of the form: `import { foo } from 'projectName'`
       const root = mkImportRegex(settings.projectName)

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -236,12 +236,14 @@ const replaceProjectName = (source: string): Program<string> =>
   pipe(
     RTE.ask<Environment>(),
     RTE.map(({ settings }) => {
+      const mkImportRegex = (projectName: string) => new RegExp(`from '${projectName}'`, 'g')
+
       // Matches imports of the form: `import { foo } from 'projectName'`
-      const root = new RegExp(`from '${settings.projectName}'`, 'g')
+      const root = mkImportRegex(settings.projectName)
       // Matches imports of the form: `import { foo } from 'projectName/lib/...'`
-      const module = new RegExp(`from '${settings.projectName}/lib/`, 'g')
+      const module = mkImportRegex(`${settings.projectName}/lib/`)
       // Matches immports of the form: `import { foo } from 'projectName/...'`
-      const other = new RegExp(`from '${settings.projectName}/`, 'g')
+      const other = mkImportRegex(`${settings.projectName}/`)
 
       return source
         .replace(root, `from '../../${settings.srcDir}'`)

--- a/test/Core.ts
+++ b/test/Core.ts
@@ -343,7 +343,7 @@ export class Foo {
         })
       })
 
-      it('should replace imports from the project with the local source folder', async () => {
+      it('should replace imports from the project with the local source folder (single quotes)', async () => {
         const state = prefixWithCwd({
           'package.json': defaultPackageJson,
           'src/utils/foo.ts': `
@@ -359,6 +359,47 @@ export class Foo {
   /**
    * @example
    * import * as Foo from '${JSON.parse(defaultPackageJson)['name']}'
+   *
+   * @since 0.0.1
+   */
+  public bar(): string {
+    return 'bar'
+  }
+}
+          `
+        })
+        const capabilities = makeCapabilities(state)
+
+        assertRight(await Core.main(capabilities)(), (result) => {
+          const exampleFileName = `${[...process.cwd().split('/'), 'src', 'utils', 'foo.ts'].join(
+            '-'
+          )}-Foo-method-bar-0.ts`
+          const exampleFilePath = `${process.cwd()}/docs/examples/${exampleFileName}`
+          const importFromRegex = new RegExp("from '../../src'")
+
+          assert.strictEqual(result, undefined)
+          assert.strictEqual(command, 'ts-node')
+          assert.strictEqual(executablePath.includes('docs/examples/index.ts'), true)
+          assert.strictEqual(importFromRegex.test(fileSystemState[exampleFilePath]), true)
+        })
+      })
+
+      it('should replace imports from the project with the local source folder (double quotes)', async () => {
+        const state = prefixWithCwd({
+          'package.json': defaultPackageJson,
+          'src/utils/foo.ts': `
+/**
+ * @since 0.0.1
+ */
+
+/**
+ * @category utils
+ * @since 0.0.1
+ */
+export class Foo {
+  /**
+   * @example
+   * import * as Foo from "${JSON.parse(defaultPackageJson)['name']}"
    *
    * @since 0.0.1
    */

--- a/test/Core.ts
+++ b/test/Core.ts
@@ -343,6 +343,47 @@ export class Foo {
         })
       })
 
+      it('should replace imports from the project with the local source folder', async () => {
+        const state = prefixWithCwd({
+          'package.json': defaultPackageJson,
+          'src/utils/foo.ts': `
+/**
+ * @since 0.0.1
+ */
+
+/**
+ * @category utils
+ * @since 0.0.1
+ */
+export class Foo {
+  /**
+   * @example
+   * import * as Foo from '${JSON.parse(defaultPackageJson)['name']}'
+   *
+   * @since 0.0.1
+   */
+  public bar(): string {
+    return 'bar'
+  }
+}
+          `
+        })
+        const capabilities = makeCapabilities(state)
+
+        assertRight(await Core.main(capabilities)(), (result) => {
+          const exampleFileName = `${[...process.cwd().split('/'), 'src', 'utils', 'foo.ts'].join(
+            '-'
+          )}-Foo-method-bar-0.ts`
+          const exampleFilePath = `${process.cwd()}/docs/examples/${exampleFileName}`
+          const importFromRegex = new RegExp("from '../../src'")
+
+          assert.strictEqual(result, undefined)
+          assert.strictEqual(command, 'ts-node')
+          assert.strictEqual(executablePath.includes('docs/examples/index.ts'), true)
+          assert.strictEqual(importFromRegex.test(fileSystemState[exampleFilePath]), true)
+        })
+      })
+
       it('should attempt to typecheck examples that include assert statements', async () => {
         const state = prefixWithCwd({
           'package.json': defaultPackageJson,


### PR DESCRIPTION
As currently there is no formatting restriction on code provided in the `@examples` section, we need to support both formats: double quotes and single quotes imports.

```ts
/**
 * @since 0.1.0
 * @category util
 * @example
 *   import * as MyProject from "my-project";
 */
export const foo = 1
```

as well as ` import * as MyProject from 'my-project';`


The PR adds a missing test, that checks if the project name is successfully replaced with single quotes. Moreover, it then adds a second test that checks if that works for double quotes, too. Implementation is provided to make the second test pass.