### PR TITLE
[WIP] replaces ts-morph with typescript 

### DIFF
--- a/src/Core.ts
+++ b/src/Core.ts
@@ -33,7 +33,6 @@ export interface Capabilities {
   readonly example: Example
   readonly fileSystem: FileSystem
   readonly logger: Logger
-  readonly ast: P.Ast
 }
 
 /**

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -317,13 +317,18 @@ const getFunctionDeclarationSignature = (f: ast.FunctionDeclaration): string => 
   )
 }
 
+const getFunctionDeclarationOverloads = (fd: ast.FunctionDeclaration): ReadonlyArray<ast.FunctionDeclaration> =>
+  pipe(
+    fd.parent.getChildren(),
+    RA.filter(ast.isFunctionDeclaration),
+    // not the best equality check. {node,fd}.id could be used instead and is internally used.
+    RA.filter((node) => node.pos !== fd.pos)
+  )
+
 const getFunctionDeclarationJSDocs = (fd: ast.FunctionDeclaration): ReadonlyArray<ast.JSDoc> =>
   pipe(
-    fd.getOverloads(),
-    RA.foldLeft(
-      () => fd.getJsDocs(),
-      (firstOverload) => firstOverload.getJsDocs()
-    )
+    getFunctionDeclarationOverloads(fd),
+    RA.foldLeft(() => getJsDocs(fd), getJsDocs)
   )
 
 const parseFunctionDeclaration = (fd: ast.FunctionDeclaration): Parser<Function> =>

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -708,13 +708,15 @@ const isStatic = (prop: ast.PropertyDeclaration): boolean =>
 
 const parseProperties = (name: string, c: ast.ClassDeclaration): Parser<ReadonlyArray<Property>> =>
   pipe(
-    c.getProperties(),
+    c,
+    children,
+    RA.filter(ast.isPropertyDeclaration),
     // take public, instance properties
     RA.filter(
       every([
-        (prop) => !prop.isStatic(),
-        (prop) => pipe(prop.getFirstModifierByKind(ast.ts.SyntaxKind.PrivateKeyword), O.fromNullable, O.isNone),
-        (prop) => pipe(prop.getJsDocs(), not(flow(getJSDocText, parseComment, shouldIgnore)))
+        not(isStatic),
+        (prop) => pipe(prop, getFirstModifierByKind(ast.SyntaxKind.PrivateKeyword), O.isNone),
+        (prop) => pipe(prop, getJsDocs, not(flow(getJSDocText, parseComment, shouldIgnore)))
       ])
     ),
     traverse(parseProperty(name))

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -603,6 +603,13 @@ const getMethodSignature = (md: ast.MethodDeclaration): string =>
     )
   )
 
+const getMethodName = (md: ast.MethodDeclaration) =>
+  pipe(
+    md,
+    children,
+    RA.findFirst(ast.isIdentifier),
+    O.map((a) => a.getText())
+  )
 const parseMethod = (md: ast.MethodDeclaration): Parser<O.Option<Method>> =>
   pipe(
     RE.of<ParserEnv, string, string>(md.getName()),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -563,7 +563,14 @@ const parseExportSpecifier = (es: ast.ExportSpecifier): Parser<Export> =>
   )
 
 const parseExportDeclaration = (ed: ast.ExportDeclaration): Parser<ReadonlyArray<Export>> =>
-  pipe(ed.getNamedExports(), traverse(parseExportSpecifier))
+  pipe(
+    ed,
+    children,
+    RA.filter(ast.isNamedExports),
+    RA.chain((node) => node.elements),
+    traverse(parseExportSpecifier)
+  )
+
 
 /**
  * @category parsers

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -336,7 +336,8 @@ const parseFunctionDeclaration = (fd: ast.FunctionDeclaration): Parser<Function>
     RE.ask<ParserEnv>(),
     RE.chain<ParserEnv, string, ParserEnv, string>((env) =>
       pipe(
-        O.fromNullable(fd.getName()),
+        O.fromNullable(fd.name),
+        O.map((name) => name.getText()),
         O.chain(O.fromPredicate((name) => name.length > 0)),
         RE.fromOption(() => `Missing function name in module ${env.path.join('/')}`)
       )
@@ -347,7 +348,7 @@ const parseFunctionDeclaration = (fd: ast.FunctionDeclaration): Parser<Function>
         getCommentInfo(name),
         RE.map((info) => {
           const signatures = pipe(
-            fd.getOverloads(),
+            getFunctionDeclarationOverloads(fd),
             RA.foldRight(
               () => RA.of(getFunctionDeclarationSignature(fd)),
               (init, last) => RA.snoc(init.map(getFunctionDeclarationSignature), getFunctionDeclarationSignature(last))

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -610,6 +610,30 @@ const getMethodName = (md: ast.MethodDeclaration) =>
     RA.findFirst(ast.isIdentifier),
     O.map((a) => a.getText())
   )
+
+// match same name, ensure body doesn't exist.
+export const getOverloads = (md: ast.MethodDeclaration): ReadonlyArray<ast.MethodDeclaration> =>
+  pipe(
+    md.parent,
+    children,
+    RA.filter(ast.isMethodDeclaration),
+    // matches method name
+    RA.filter((md1) =>
+      pipe(
+        getMethodName(md1),
+        O.chain((md1) =>
+          pipe(
+            getMethodName(md),
+            O.map((md) => md === md1)
+          )
+        ),
+        O.getOrElse((): boolean => false)
+      )
+    ),
+    // not the implemtnation
+    RA.filter((a) => !a.body)
+  )
+
 const parseMethod = (md: ast.MethodDeclaration): Parser<O.Option<Method>> =>
   pipe(
     RE.of<ParserEnv, string, string>(md.getName()),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -268,11 +268,11 @@ export const parseComment = (text: string): Comment => {
 
 const parseInterfaceDeclaration = (id: ast.InterfaceDeclaration): Parser<Interface> =>
   pipe(
-    getJSDocText(id.getJsDocs()),
-    getCommentInfo(id.getName()),
+    getJSDocText(pipe(id.getChildren(), RA.filter(ast.isJSDoc))),
+    getCommentInfo(id.name.text),
     RE.map((info) =>
       Interface(
-        Documentable(id.getName(), info.description, info.since, info.deprecated, info.examples, info.category),
+        Documentable(id.name.text, info.description, info.since, info.deprecated, info.examples, info.category),
         id.getText()
       )
     )

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -379,6 +379,9 @@ const parseFunctionVariableDeclaration = (vd: ast.VariableDeclaration): Parser<F
   )
 }
 
+const getFunctions = (sourceFile: ast.SourceFile) =>
+  pipe(sourceFile.getChildren(), RA.filter(ast.isFunctionDeclaration))
+
 const getFunctionDeclarations: RE.ReaderEither<
   ParserEnv,
   string,

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -14,7 +14,7 @@ import * as RNEA from 'fp-ts/ReadonlyNonEmptyArray'
 import * as RR from 'fp-ts/ReadonlyRecord'
 import * as S from 'fp-ts/Semigroup'
 import { flow, not, pipe, Endomorphism, Predicate } from 'fp-ts/function'
-import * as ast from 'ts-morph'
+import * as ast from 'typescript'
 import * as doctrine from 'doctrine'
 import * as Path from 'path'
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -506,22 +506,22 @@ const parseConstantVariableDeclaration = (vd: ast.VariableDeclaration): Parser<C
 export const parseConstants: Parser<ReadonlyArray<Constant>> = pipe(
   RE.asks((env: ParserEnv) =>
     pipe(
-      env.sourceFile.getVariableDeclarations(),
+      getVariableDeclarations(env.sourceFile),
       RA.filter(
         every([
-          (vd) => isVariableDeclarationList(vd.getParent()),
-          (vd) => isVariableStatement(vd.getParent().getParent() as any),
+          (vd) => isVariableDeclarationList(vd.parent),
+          (vd) => isVariableStatement(vd.parent.parent as any),
           (vd) =>
             pipe(
-              vd.getInitializer(),
+              vd.initializer,
               every([
-                flow(O.fromNullable, O.chain(O.fromPredicate(not(ast.Node.isFunctionLikeDeclaration))), O.isSome),
+                flow(O.fromNullable, O.chain(O.fromPredicate(not(ast.isFunctionLike))), O.isSome),
                 () =>
                   pipe(
-                    (vd.getParent().getParent() as ast.VariableStatement).getJsDocs(),
+                    getJsDocs(vd.parent.parent as ast.VariableStatement),
                     not(flow(getJSDocText, parseComment, shouldIgnore))
                   ),
-                () => (vd.getParent().getParent() as ast.VariableStatement).isExported()
+                () => isExported(vd.parent.parent as ast.VariableStatement)
               ])
             )
         ])

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -444,10 +444,10 @@ export const parseFunctions: Parser<ReadonlyArray<Function>> = pipe(
 
 const parseTypeAliasDeclaration = (ta: ast.TypeAliasDeclaration): Parser<TypeAlias> =>
   pipe(
-    RE.of<ParserEnv, string, string>(ta.getName()),
+    RE.of<ParserEnv, string, string>(ta.name.text),
     RE.chain((name) =>
       pipe(
-        getJSDocText(ta.getJsDocs()),
+        getJSDocText(getJsDocs(ta)),
         getCommentInfo(name),
         RE.map((info) =>
           TypeAlias(

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -636,17 +636,14 @@ export const getOverloads = (md: ast.MethodDeclaration): ReadonlyArray<ast.Metho
 
 const parseMethod = (md: ast.MethodDeclaration): Parser<O.Option<Method>> =>
   pipe(
-    RE.of<ParserEnv, string, string>(md.getName()),
+    RE.of<ParserEnv, string, string>(md.name.getText()),
     RE.bindTo('name'),
-    RE.bind('overloads', () => RE.of(md.getOverloads())),
+    RE.bind('overloads', () => RE.of(getOverloads(md))),
     RE.bind('jsdocs', ({ overloads }) =>
       RE.of(
         pipe(
           overloads,
-          RA.foldLeft(
-            () => md.getJsDocs(),
-            (x) => x.getJsDocs()
-          )
+          RA.foldLeft(() => getJsDocs(md), getJsDocs)
         )
       )
     ),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -778,8 +778,8 @@ const parseClass = (c: ast.ClassDeclaration): Parser<Class> =>
     RE.bindTo('name'),
     RE.bind('info', ({ name }) => getClassCommentInfo(name, c)),
     RE.bind('signature', ({ name }) => getClassDeclarationSignature(name, c)),
-    RE.bind('methods', () => pipe(c.getInstanceMethods(), traverse(parseMethod), RE.map(RA.compact))),
-    RE.bind('staticMethods', () => pipe(c.getStaticMethods(), traverse(parseMethod), RE.map(RA.compact))),
+    RE.bind('methods', () => pipe(c, getInstanceMethods, traverse(parseMethod), RE.map(RA.compact))),
+    RE.bind('staticMethods', () => pipe(c, getStaticMethods, traverse(parseMethod), RE.map(RA.compact))),
     RE.bind('properties', ({ name }) => parseProperties(name, c)),
     RE.map(({ methods, staticMethods, properties, info, name, signature }) =>
       Class(

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -703,8 +703,8 @@ const parseProperty = (classname: string) => (pd: ast.PropertyDeclaration): Pars
 const getFirstModifierByKind = <T extends ast.SyntaxKind>(kind: T) => <N extends ast.Node>(prop: N) =>
   pipe(prop.modifiers, O.fromNullable, O.chain(RA.findFirst((modifier) => modifier.kind === kind)))
 
-const isStatic = (prop: ast.PropertyDeclaration): boolean =>
-  pipe(prop, getFirstModifierByKind(ast.SyntaxKind.StaticKeyword), O.isSome)
+const isStatic = <T extends ast.ClassElement>(node: T) =>
+  pipe(node, getFirstModifierByKind(ast.SyntaxKind.StaticKeyword), O.isSome)
 
 const parseProperties = (name: string, c: ast.ClassDeclaration): Parser<ReadonlyArray<Property>> =>
   pipe(

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -696,7 +696,7 @@ const getClassName = (c: ast.ClassDeclaration): Parser<string> =>
     RE.ask<ParserEnv>(),
     RE.chain<ParserEnv, string, ParserEnv, string>((env) =>
       pipe(
-        O.fromNullable(c.getName()),
+        O.fromNullable(c.name?.text),
         RE.fromOption(() => `Missing class name in module ${env.path.join('/')}`)
       )
     )

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -703,6 +703,9 @@ const parseProperty = (classname: string) => (pd: ast.PropertyDeclaration): Pars
 const getFirstModifierByKind = <T extends ast.SyntaxKind>(kind: T) => <N extends ast.Node>(prop: N) =>
   pipe(prop.modifiers, O.fromNullable, O.chain(RA.findFirst((modifier) => modifier.kind === kind)))
 
+const isStatic = (prop: ast.PropertyDeclaration): boolean =>
+  pipe(prop, getFirstModifierByKind(ast.SyntaxKind.StaticKeyword), O.isSome)
+
 const parseProperties = (name: string, c: ast.ClassDeclaration): Parser<ReadonlyArray<Property>> =>
   pipe(
     c.getProperties(),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -307,7 +307,7 @@ export const parseInterfaces: Parser<ReadonlyArray<Interface>> = pipe(
 const getFunctionDeclarationSignature = (f: ast.FunctionDeclaration): string => {
   const text = f.getText()
   return pipe(
-    O.fromNullable(f.compilerNode.body),
+    O.fromNullable(f.body),
     O.fold(
       () => text.replace('export function ', 'export declare function '),
       (body) => {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -766,6 +766,9 @@ const getClassDeclarationSignature = (name: string, c: ast.ClassDeclaration): Pa
     )
   )
 
+const getStaticMethods = (c: ast.ClassDeclaration): ReadonlyArray<ast.MethodDeclaration> =>
+  pipe(c.members, RA.filter(ast.isMethodDeclaration), RA.filter(isStatic))
+
 const parseClass = (c: ast.ClassDeclaration): Parser<Class> =>
   pipe(
     getClassName(c),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -649,14 +649,15 @@ const parseMethod = (md: ast.MethodDeclaration): Parser<O.Option<Method>> =>
   )
 
 const parseProperty = (classname: string) => (pd: ast.PropertyDeclaration): Parser<Property> => {
-  const name = pd.getName()
+  const name = pd.name.getText()
   return pipe(
-    getJSDocText(pd.getJsDocs()),
+    getJSDocText(getJsDocs(pd)),
     getCommentInfo(`${classname}#${name}`),
     RE.map((info) => {
-      const type = stripImportTypes(pd.getType().getText(pd))
+      const type = stripImportTypes(pd.type?.getText(pd as any) as string)
       const readonly = pipe(
-        O.fromNullable(pd.getFirstModifierByKind(ast.ts.SyntaxKind.ReadonlyKeyword)),
+        O.fromNullable(pd.modifiers),
+        O.chain(RA.findFirst((modifier) => modifier.kind === ast.SyntaxKind.ReadonlyKeyword)),
         O.fold(
           () => '',
           () => 'readonly '

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -364,13 +364,13 @@ const parseFunctionDeclaration = (fd: ast.FunctionDeclaration): Parser<Function>
   )
 
 const parseFunctionVariableDeclaration = (vd: ast.VariableDeclaration): Parser<Function> => {
-  const vs: any = vd.getParent().getParent()
-  const name = vd.getName()
+  const vs = vd.parent.parent
+  const name = vd.name.getText()
   return pipe(
-    getJSDocText(vs.getJsDocs()),
+    getJSDocText(getJsDocs(vs)),
     getCommentInfo(name),
     RE.map((info) => {
-      const signature = `export declare const ${name}: ${stripImportTypes(vd.getType().getText(vd))}`
+      const signature = `export declare const ${name}: ${stripImportTypes(vd.type?.getText(vd as any) as string)}`
       return Function(
         Documentable(name, info.description, info.since, info.deprecated, info.examples, info.category),
         RA.of(signature)

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -459,6 +459,8 @@ const parseTypeAliasDeclaration = (ta: ast.TypeAliasDeclaration): Parser<TypeAli
     )
   )
 
+const children = <R extends ast.Node>(node: R) => RA.fromArray(node.getChildren())
+
 /**
  * @category parsers
  * @since 0.6.0

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -461,6 +461,8 @@ const parseTypeAliasDeclaration = (ta: ast.TypeAliasDeclaration): Parser<TypeAli
 
 const children = <R extends ast.Node>(node: R) => RA.fromArray(node.getChildren())
 
+const getTypeAliases = (sourceFile: ast.SourceFile) => pipe(sourceFile, children, RA.filter(ast.isTypeAliasDeclaration))
+
 /**
  * @category parsers
  * @since 0.6.0

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -262,13 +262,15 @@ export const parseComment = (text: string): Comment => {
   return { description, tags }
 }
 
+const getJsDocs = (id: ast.Node) => pipe(id.getChildren(), RA.filter(ast.isJSDoc))
+
 // -------------------------------------------------------------------------------------
 // interfaces
 // -------------------------------------------------------------------------------------
 
 const parseInterfaceDeclaration = (id: ast.InterfaceDeclaration): Parser<Interface> =>
   pipe(
-    getJSDocText(pipe(id.getChildren(), RA.filter(ast.isJSDoc))),
+    getJSDocText(getJsDocs(id)),
     getCommentInfo(id.name.text),
     RE.map((info) =>
       Interface(

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -470,13 +470,8 @@ const getTypeAliases = (sourceFile: ast.SourceFile) => pipe(sourceFile, children
 export const parseTypeAliases: Parser<ReadonlyArray<TypeAlias>> = pipe(
   RE.asks((env: ParserEnv) =>
     pipe(
-      env.sourceFile.getTypeAliases(),
-      RA.filter(
-        every([
-          (alias) => alias.isExported(),
-          (alias) => pipe(alias.getJsDocs(), not(flow(getJSDocText, parseComment, shouldIgnore)))
-        ])
-      )
+      getTypeAliases(env.sourceFile),
+      RA.filter(every([isExported, flow(getJsDocs, not(flow(getJSDocText, parseComment, shouldIgnore)))]))
     )
   ),
   RE.chain(traverse(parseTypeAliasDeclaration)),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -703,7 +703,7 @@ const getClassName = (c: ast.ClassDeclaration): Parser<string> =>
   )
 
 const getClassCommentInfo = (name: string, c: ast.ClassDeclaration): Parser<CommentInfo> =>
-  pipe(c.getJsDocs(), getJSDocText, getCommentInfo(name))
+  pipe(c, getJsDocs, getJSDocText, getCommentInfo(name))
 
 const getClassDeclarationSignature = (name: string, c: ast.ClassDeclaration): Parser<string> =>
   pipe(

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -579,7 +579,7 @@ const getExportDeclarations = (sourceFile: ast.SourceFile) =>
  * @since 0.6.0
  */
 export const parseExports: Parser<ReadonlyArray<Export>> = pipe(
-  RE.asks((env: ParserEnv) => env.sourceFile.getExportDeclarations()),
+  RE.asks((env: ParserEnv) => getExportDeclarations(env.sourceFile)),
   RE.chain(traverse(parseExportDeclaration)),
   RE.map(RA.flatten)
 )

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -727,7 +727,7 @@ const parseProperties = (name: string, c: ast.ClassDeclaration): Parser<Readonly
  */
 export const getConstructorDeclarationSignature = (c: ast.ConstructorDeclaration): string =>
   pipe(
-    O.fromNullable(c.compilerNode.body),
+    O.fromNullable(c.body),
     O.fold(
       () => c.getText(),
       (body) => {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -280,24 +280,21 @@ const parseInterfaceDeclaration = (id: ast.InterfaceDeclaration): Parser<Interfa
     )
   )
 
-/**
- * @category parsers
- * @since 0.6.0
- */
-export const parseInterfaces: Parser<ReadonlyArray<Interface>> = pipe(
-  RE.asks<ParserEnv, string, ReadonlyArray<ast.InterfaceDeclaration>>((env) =>
-    pipe(
-      env.sourceFile.getChildren(),
-      RA.filter(ast.isInterfaceDeclaration),
-      RA.filter((node) =>
+export const isExported = <N extends ast.Node>(node: N) =>
         pipe(
           node.modifiers,
           O.fromNullable,
           O.map(RA.foldMap(M.monoidAny)((ma) => ma.kind === ast.SyntaxKind.ExportKeyword)),
           O.getOrElse((): boolean => false)
         )
-      )
-    )
+
+/**
+ * @category parsers
+ * @since 0.6.0
+ */
+export const parseInterfaces: Parser<ReadonlyArray<Interface>> = pipe(
+  RE.asks<ParserEnv, string, ReadonlyArray<ast.InterfaceDeclaration>>((env) =>
+    pipe(env.sourceFile.getChildren(), RA.filter(ast.isInterfaceDeclaration), RA.filter(isExported))
   ),
   RE.chain(flow(traverse(parseInterfaceDeclaration), RE.map(RA.sort(ordByName))))
 )

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -593,7 +593,7 @@ const getTypeParameters = (tps: ReadonlyArray<ast.TypeParameterDeclaration>): st
 
 const getMethodSignature = (md: ast.MethodDeclaration): string =>
   pipe(
-    O.fromNullable(md.compilerNode.body),
+    O.fromNullable(md.body),
     O.fold(
       () => md.getText(),
       (body) => {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -672,6 +672,9 @@ const parseProperty = (classname: string) => (pd: ast.PropertyDeclaration): Pars
   )
 }
 
+const getFirstModifierByKind = <T extends ast.SyntaxKind>(kind: T) => <N extends ast.Node>(prop: N) =>
+  pipe(prop.modifiers, O.fromNullable, O.chain(RA.findFirst((modifier) => modifier.kind === kind)))
+
 const parseProperties = (name: string, c: ast.ClassDeclaration): Parser<ReadonlyArray<Property>> =>
   pipe(
     c.getProperties(),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -142,11 +142,11 @@ const shouldIgnore: Predicate<Comment> = some([
 
 const isVariableDeclarationList = (
   u: ast.VariableDeclarationList | ast.CatchClause
-): u is ast.VariableDeclarationList => u.getKind() === ast.ts.SyntaxKind.VariableDeclarationList
+): u is ast.VariableDeclarationList => u.kind === ast.SyntaxKind.VariableDeclarationList
 
 const isVariableStatement = (
   u: ast.VariableStatement | ast.ForStatement | ast.ForOfStatement | ast.ForInStatement
-): u is ast.VariableStatement => u.getKind() === ast.ts.SyntaxKind.VariableStatement
+): u is ast.VariableStatement => u.kind === ast.SyntaxKind.VariableStatement
 
 /**
  * @internal

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -59,8 +59,8 @@ export interface ParserEnv extends Environment {
  * @since 0.6.0
  */
 export interface Ast {
-  readonly project: ast.Project
-  readonly addFile: (file: File) => R.Reader<ast.Project, void>
+  readonly project: ast.Program
+  readonly addFile: (file: File) => R.Reader<ast.Program, void>
 }
 
 interface Comment {
@@ -151,7 +151,7 @@ const isVariableStatement = (
 /**
  * @internal
  */
-export const addFileToProject = (file: File) => (project: ast.Project) => project.addSourceFileAtPath(file.path)
+export const addFileToProject = (file: File) => (project: ast.Program) => project.addSourceFileAtPath(file.path)
 
 // -------------------------------------------------------------------------------------
 // comments
@@ -810,7 +810,7 @@ export const parseModule: Parser<Module> = pipe(
 /**
  * @internal
  */
-export const parseFile = (project: ast.Project) => (file: File): RTE.ReaderTaskEither<Environment, string, Module> =>
+export const parseFile = (project: ast.Program) => (file: File): RTE.ReaderTaskEither<Environment, string, Module> =>
   pipe(
     RTE.ask<Environment>(),
     RTE.chain((env) =>
@@ -830,7 +830,7 @@ export const parseFile = (project: ast.Project) => (file: File): RTE.ReaderTaskE
     )
   )
 
-const createProject = (files: ReadonlyArray<File>): RTE.ReaderTaskEither<Environment, string, ast.Project> =>
+const createProject = (files: ReadonlyArray<File>): RTE.ReaderTaskEither<Environment, string, ast.Program> =>
   pipe(
     RTE.ask<Environment>(),
     RTE.chainFirst(({ ast }) =>

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -769,6 +769,9 @@ const getClassDeclarationSignature = (name: string, c: ast.ClassDeclaration): Pa
 const getStaticMethods = (c: ast.ClassDeclaration): ReadonlyArray<ast.MethodDeclaration> =>
   pipe(c.members, RA.filter(ast.isMethodDeclaration), RA.filter(isStatic))
 
+const getInstanceMethods = (c: ast.ClassDeclaration): ReadonlyArray<ast.MethodDeclaration> =>
+  pipe(c.members, RA.filter(ast.isMethodDeclaration), RA.filter(not(isStatic)))
+
 const parseClass = (c: ast.ClassDeclaration): Parser<Class> =>
   pipe(
     getClassName(c),

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -589,7 +589,7 @@ export const parseExports: Parser<ReadonlyArray<Export>> = pipe(
 // -------------------------------------------------------------------------------------
 
 const getTypeParameters = (tps: ReadonlyArray<ast.TypeParameterDeclaration>): string =>
-  tps.length === 0 ? '' : `<${tps.map((p) => p.getName()).join(', ')}>`
+  tps.length === 0 ? '' : `<${tps.map((p) => p.name.text).join(', ')}>`
 
 const getMethodSignature = (md: ast.MethodDeclaration): string =>
   pipe(

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -382,6 +382,9 @@ const parseFunctionVariableDeclaration = (vd: ast.VariableDeclaration): Parser<F
 const getFunctions = (sourceFile: ast.SourceFile) =>
   pipe(sourceFile.getChildren(), RA.filter(ast.isFunctionDeclaration))
 
+const getVariableDeclarations = (soureceFile: ast.SourceFile) =>
+  pipe(soureceFile.getChildren(), RA.filter(ast.isVariableDeclaration))
+
 const getFunctionDeclarations: RE.ReaderEither<
   ParserEnv,
   string,

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -571,6 +571,8 @@ const parseExportDeclaration = (ed: ast.ExportDeclaration): Parser<ReadonlyArray
     traverse(parseExportSpecifier)
   )
 
+const getExportDeclarations = (sourceFile: ast.SourceFile) =>
+  pipe(sourceFile, children, RA.filter(ast.isExportDeclaration))
 
 /**
  * @category parsers

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -483,13 +483,13 @@ export const parseTypeAliases: Parser<ReadonlyArray<TypeAlias>> = pipe(
 // -------------------------------------------------------------------------------------
 
 const parseConstantVariableDeclaration = (vd: ast.VariableDeclaration): Parser<Constant> => {
-  const vs: any = vd.getParent().getParent()
-  const name = vd.getName()
+  const vs: any = vd.parent.parent
+  const name = vd.name.getText()
   return pipe(
-    getJSDocText(vs.getJsDocs()),
+    getJSDocText(getJsDocs(vs)),
     getCommentInfo(name),
     RE.map((info) => {
-      const type = stripImportTypes(vd.getType().getText(vd))
+      const type = stripImportTypes(vd.type?.getText(vd as any) as string)
       const signature = `export declare const ${name}: ${type}`
       return Constant(
         Documentable(name, info.description, info.since, info.deprecated, info.examples, info.category),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,9 @@ import * as IO from 'fp-ts/IO'
 import { pipe } from 'fp-ts/pipeable'
 import * as T from 'fp-ts/Task'
 import * as TE from 'fp-ts/TaskEither'
-import * as ast from 'ts-morph'
+import * as ast from 'typescript'
 
 import * as Core from './Core'
-import * as Parser from './Parser'
 import { Example } from './Example'
 import { FileSystem } from './FileSystem'
 import { Logger } from './Logger'
@@ -43,20 +42,14 @@ export const exit: (program: TE.TaskEither<string, void>) => T.Task<void> = TE.f
 /**
  * @internal
  */
-export const compilerOptions: ast.ProjectOptions['compilerOptions'] = {
+export const compilerOptions: ast.CompilerOptions = {
   strict: true
 }
 
 const capabilities: Core.Capabilities = {
   example: Example,
   fileSystem: FileSystem,
-  logger: Logger,
-  ast: {
-    project: new ast.Project({
-      compilerOptions
-    }),
-    addFile: Parser.addFileToProject
-  }
+  logger: Logger
 }
 
 /**

--- a/src/tsc/index.ts
+++ b/src/tsc/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Helper functions for using the typescript compiler API
+ *
+ * @todo separate into what they take as arguments
+ */
+import { reader as R, readonlyArray as RA } from 'fp-ts'
+import { flow, pipe } from 'fp-ts/lib/function'
+import * as ast from 'typescript'
+import { isExportModifier, isPrivateKeyword, isStaticKeyword } from './modifier'
+
+export function children<N extends ast.Node>(node: N): ReadonlyArray<ast.Node> {
+  return node.getChildren()
+}
+
+export function forEachChild<N extends ast.Node>(node: N): ReadonlyArray<ast.Node> {
+  const fa: Array<ast.Node> = []
+  node.forEachChild((node) => fa.push(node))
+  return fa
+}
+
+export function prop<K extends string>(property: K): <T extends Record<K, unknown>>(fa: T) => T[K] {
+  return (fa) => fa[property]
+}
+
+export function modifiers<N extends ast.Node>(node: N): ReadonlyArray<ast.Modifier> {
+  return node.modifiers || []
+}
+
+export function kind<N extends ast.Node>(node: N): ast.SyntaxKind {
+  return node.kind
+}
+
+export function parent<N extends ast.Node>(node: N): ast.Node {
+  return node.parent
+}
+
+export const isStatic = <T extends ast.ClassElement>(node: T) => pipe(node, modifiers, RA.some(isStaticKeyword))
+export const isPrivate = <T extends ast.ClassElement>(node: T) => pipe(node, modifiers, RA.some(isPrivateKeyword))
+
+export function isExported<N extends ast.Node>(node: N): boolean {
+  return pipe(node, forEachChild, RA.some(flow(modifiers, RA.some(isExportModifier))))
+}
+
+export const jsDocComments = <N extends ast.Node>(node: N): ReadonlyArray<ast.JSDoc> =>
+  pipe(node, forEachChild, RA.chain(children), RA.filter(ast.isJSDoc))
+
+// should this be an ReaderIO?
+export function text<T extends ast.TextRange>({ pos, end }: T): R.Reader<ast.SourceFile, string> {
+  return (sourceFile) => sourceFile.getFullText().substring(pos, end)
+}
+
+export function getTypeParameters<
+  N extends Partial<Record<'typeParameters', ast.NodeArray<ast.TypeParameterDeclaration>>>
+>(c: N): ReadonlyArray<ast.TypeParameterDeclaration> {
+  return c.typeParameters || []
+}
+
+export function getConstructors(c: ast.ClassDeclaration) {
+  return pipe(c, prop('members'), RA.filter(ast.isConstructorDeclaration))
+}

--- a/src/tsc/modifier.ts
+++ b/src/tsc/modifier.ts
@@ -1,0 +1,13 @@
+import * as ast from 'typescript'
+
+export function isExportModifier(modifier: ast.Modifier): modifier is ast.ExportKeyword {
+  return modifier.kind === ast.SyntaxKind.ExportKeyword
+}
+
+export function isStaticKeyword(modifier: ast.Modifier): modifier is ast.StaticKeyword {
+  return modifier.kind === ast.SyntaxKind.StaticKeyword
+}
+
+export function isPrivateKeyword(modifier: ast.Modifier): modifier is ast.PrivateKeyword {
+  return modifier.kind === ast.SyntaxKind.PrivateKeyword
+}

--- a/test/Core.ts
+++ b/test/Core.ts
@@ -7,7 +7,6 @@ import * as R from 'fp-ts/Record'
 import * as A from 'fp-ts/Array'
 import { eqString } from 'fp-ts/Eq'
 import { pipe, Endomorphism } from 'fp-ts/function'
-import * as ast from 'ts-morph'
 
 import * as Core from '../src/Core'
 import * as E from '../src/Example'
@@ -103,11 +102,7 @@ const makeCapabilities: (state: FileSystemState) => Core.Capabilities = (state) 
   return {
     logger,
     fileSystem,
-    example,
-    ast: {
-      project: new ast.Project({ useInMemoryFileSystem: true }),
-      addFile: (file) => (project) => project.createSourceFile(file.path, file.content, { overwrite: file.overwrite })
-    }
+    example
   }
 }
 


### PR DESCRIPTION
## Summary

ts-morph doesn't stay up to date with new versions of typescript.
I've tried to run doc-ts with valid Typescript, with ts-morph throwing errors using syntax the authors haven't implemented it to recognize. The example is `export * as namespace from 'module'`, which ts-morph throws errors on. See #27 for further information.

I understand the performance benefits of ts-morph, but I doubt the benefit of speed will outweigh the lack of compatible with current typescript features.

## For the Curious

I've been using https://ts-ast-viewer.com/ as a visual guide how the AST works and what information I'm trying to extract.

**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/gcanti/docs-ts) and create your branch from `master`.
- [x] Run `npm install` in the repository root.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`npm test`).

